### PR TITLE
Fixed typo in documentation "secondss" -> "seconds"

### DIFF
--- a/lib/DateTime/Format/Epoch.pm
+++ b/lib/DateTime/Format/Epoch.pm
@@ -208,7 +208,7 @@ DateTime::Format::Epoch - Convert DateTimes to/from epoch seconds
                       epoch          => $dt,
                       unit           => 'seconds',
                       type           => 'int',    # or 'float', 'bigint'
-                      skip_leap_secondss => 1,
+                      skip_leap_seconds => 1,
                       start_at       => 0,
                       local_epoch    => undef,
                   );


### PR DESCRIPTION
Fixed a typo in the documentation (the synopsis has two "s"s at the end of skip_lead_seconds)
